### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-07-11
+
+### Changed:
+
+- Snippets: All snippets that reference schemas updated to use `v0.19.1` schema
+
 ## [0.5.0] - 2024-06-27
 
-### Added: 
+### Added:
 
 - Snippets: `devproxy-plugin-api-center-minimal-permissions` - ApiCenterMinimalPermissionsPlugin instance
 - Snippets: `devproxy-plugin-api-center-minimal-permissions-config` - ApiCenterMinimalPermissionsPlugin config section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Snippets: All snippets that reference schemas updated to use `v0.19.1` schema
 - Snippets: Removed `configSection` from `devproxy-plugin-graph-minimal-permissions`
+- Snippets: Updated `configSection` names to be unique
 
 ### Removed:
 
 - Snippets: `devproxy-plugin-graph-minimal-permissions-config`
+
+### Added:
+
+- Snippet: `devproxy-plugin-graph-mock-response-config` - GraphMockResponsePlugin config section
 
 ## [0.5.0] - 2024-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - Snippets: All snippets that reference schemas updated to use `v0.19.1` schema
+- Snippets: Removed `configSection` from `devproxy-plugin-graph-minimal-permissions`
+
+### Removed:
+
+- Snippets: `devproxy-plugin-graph-minimal-permissions-config`
 
 ## [0.5.0] - 2024-06-27
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The following sections describe the features that the extension contributes to V
 | `devproxy-plugin-latency-config` | LatencyPlugin config section |
 | `devproxy-plugin-graph-minimal-permissions-guidance` | MinimalPermissionsGuidancePlugin instance |
 | `devproxy-plugin-graph-minimal-permissions` | MinimalPermissionsPlugin instance |
-| `devproxy-plugin-graph-minimal-permissions-config` | MinimalPermissionsPlugin config section |
 | `devproxy-plugin-mock-generator` | MockGeneratorPlugin instance |
 | `devproxy-plugin-mock-request` | MockResponsePlugin instance |
 | `devproxy-plugin-mock-request-config` | MockResponsePlugin config section |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following sections describe the features that the extension contributes to V
 | `devproxy-plugin-graph-beta-support-guidance` | GraphBetaSupportGuidancePlugin instance |
 | `devproxy-plugin-graph-client-request-id-guidance` | GraphClientRequestIdGuidancePlugin instance |
 | `devproxy-plugin-graph-mock-response` | GraphMockResponsePlugin instance |
+| `devproxy-plugin-graph-mock-response-config` | GraphMockResponsePlugin config section |
 | `devproxy-plugin-graph-random-error` | GraphRandomErrorPlugin instance |
 | `devproxy-plugin-graph-random-error-config` | GraphRandomErrorPlugin config section |
 | `devproxy-plugin-graph-sdk-guidance` | GraphSdkGuidancePlugin instance |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Dev Proxy Toolkit extension for Visual Studio Code makes it easy to create a
 
 > **IMPORTANT**
 >
-> Dev Proxy Toolkit is designed to be used with the latest version of Dev Proxy, v0.19.0. If you are using an earlier build some features may not work as intended.
+> Dev Proxy Toolkit is designed to be used with the latest version of Dev Proxy, v0.19.1. If you are using an earlier build some features may not work as intended.
 >
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dev-proxy-toolkit",
   "displayName": "Dev Proxy Toolkit",
   "description": "Makes it easy to create and update Dev Proxy configuration files.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "garrytrinder",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/snippets.json
+++ b/src/snippets.json
@@ -537,20 +537,10 @@
       "{",
       "\t\"name\": \"MinimalPermissionsPlugin\",",
       "\t\"enabled\": true,",
-      "\t\"pluginPath\": \"~appFolder/plugins/dev-proxy-plugins.dll\",",
-      "\t\"configSection\": \"minimalPermissionsPlugin\"",
+      "\t\"pluginPath\": \"~appFolder/plugins/dev-proxy-plugins.dll\"",
       "}"
     ],
     "description": "MinimalPermissionsPlugin instance"
-  },
-  "MinimalPermissionsPluginConfig": {
-    "prefix": "devproxy-plugin-graph-minimal-permissions-config",
-    "body": [
-      "\"minimalPermissionsPlugin\": {",
-      "\t\"type\": \"delegated\"",
-      "}"
-    ],
-    "description": "MinimalPermissionsPlugin config section"
   },
   "MockGeneratorPlugin": {
     "prefix": "devproxy-plugin-mock-generator",

--- a/src/snippets.json
+++ b/src/snippets.json
@@ -269,7 +269,7 @@
       "\t\"name\": \"EntraMockResponsePlugin\",",
       "\t\"enabled\": true,",
       "\t\"pluginPath\": \"~appFolder/plugins/dev-proxy-plugins.dll\",",
-      "\t\"configSection\": \"mocksPlugin\"",
+      "\t\"configSection\": \"entraMockResponsePlugin\"",
       "}"
     ],
     "description": "EntraMockResponsePlugin instance"
@@ -277,7 +277,7 @@
   "EntraMockResponsePluginConfig": {
     "prefix": "devproxy-plugin-entra-mock-response-config",
     "body": [
-      "\"mocksPlugin\": {",
+      "\"entraMockResponsePlugin\": {",
       "\t\"mocksFile\": \"mocks.json\"",
       "}"
     ],
@@ -389,7 +389,7 @@
       "\t\"name\": \"GraphMockResponsePlugin\",",
       "\t\"enabled\": true,",
       "\t\"pluginPath\": \"~appFolder/plugins/dev-proxy-plugins.dll\",",
-      "\t\"configSection\": \"mocksPlugin\",",
+      "\t\"configSection\": \"graphMockResponsePlugin\",",
       "\t\"urlsToWatch\": [",
       "\t\t\"https://graph.microsoft.com/v1.0/*\",",
       "\t\t\"https://graph.microsoft.com/beta/*\",",
@@ -403,6 +403,15 @@
       "}"
     ],
     "description": "GraphMockResponsePlugin instance"
+  },
+  "GraphMockResponsePluginConfig": {
+    "prefix": "devproxy-plugin-graph-mock-response-config",
+    "body": [
+      "\"graphMockResponsePlugin\": {",
+      "\t\"mocksFile\": \"mocks.json\"",
+      "}"
+    ],
+    "description": "GraphMockResponsePlugin config section"
   },
   "GraphRandomErrorPlugin": {
     "prefix": "devproxy-plugin-graph-random-error",
@@ -581,7 +590,7 @@
       "\t\"name\": \"MockResponsePlugin\",",
       "\t\"enabled\": true,",
       "\t\"pluginPath\": \"~appFolder/plugins/dev-proxy-plugins.dll\",",
-      "\t\"configSection\": \"mocksPlugin\"",
+      "\t\"configSection\": \"mockResponsePlugin\"",
       "}"
     ],
     "description": "MockResponsePlugin instance"
@@ -589,7 +598,7 @@
   "MockResponsePluginConfig": {
     "prefix": "devproxy-plugin-mock-response-config",
     "body": [
-      "\"mocksPlugin\": {",
+      "\"mockResponsePlugin\": {",
       "\t\"mocksFile\": \"mocks.json\"",
       "}"
     ],

--- a/src/snippets.json
+++ b/src/snippets.json
@@ -3,7 +3,7 @@
     "prefix": "devproxy-config-file",
     "body": [
       "{",
-      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/rc.schema.json\",",
+      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/rc.schema.json\",",
       "\t\"plugins\": [",
       "\t\t$1",
       "\t],",
@@ -17,7 +17,7 @@
   "ConfigFileSchema": {
     "prefix": "devproxy-config-file-schema",
     "body": [
-      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/rc.schema.json\","
+      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/rc.schema.json\","
     ],
     "description": "Dev Proxy config file schema"
   },
@@ -25,7 +25,7 @@
     "prefix": "devproxy-mocks-file",
     "body": [
       "{",
-      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/mockresponseplugin.schema.json\",",
+      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/mockresponseplugin.schema.json\",",
       "\t\"mocks\": [",
       "\t\t$1",
       "\t]",
@@ -36,7 +36,7 @@
   "MocksFileSchema": {
     "prefix": "devproxy-mocks-file-schema",
     "body": [
-      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/mockresponseplugin.schema.json\","
+      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/mockresponseplugin.schema.json\","
     ],
     "description": "Dev Proxy mocks file schema"
   },
@@ -212,7 +212,7 @@
     "prefix": "devproxy-plugin-crud-api-file",
     "body": [
       "{",
-      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/crudapiplugin.schema.json\",",
+      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/crudapiplugin.schema.json\",",
       "\t\"actions\": [",
       "\t\t$1",
       "\t],",
@@ -225,7 +225,7 @@
   "CrudApiPluginFileSchema": {
     "prefix": "devproxy-plugin-crud-api-file-schema",
     "body": [
-      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/crudapiplugin.schema.json\","
+      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/crudapiplugin.schema.json\","
     ],
     "description": "CrudApiPlugin API file schema"
   },
@@ -329,7 +329,7 @@
     "prefix": "devproxy-plugin-generic-random-error-file",
     "body": [
       "{",
-      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/genericrandomerrorplugin.schema.json\",",
+      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/genericrandomerrorplugin.schema.json\",",
       "\t\"responses\": [",
       "\t\t$1",
       "\t]",
@@ -340,7 +340,7 @@
   "GenericRandomErrorPluginFileSchema": {
     "prefix": "devproxy-plugin-generic-random-error-file-schema",
     "body": [
-      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/genericrandomerrorplugin.schema.json\","
+      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/genericrandomerrorplugin.schema.json\","
     ],
     "description": "GenericRandomErrorPlugin errors file schema"
   },
@@ -608,7 +608,7 @@
   "MockResponsePluginFileSchema": {
     "prefix": "devproxy-plugin-mock-response-schema",
     "body": [
-      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/mockresponseplugin.schema.json\","
+      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/mockresponseplugin.schema.json\","
     ],
     "description": "MockResponsePlugin schema"
   },
@@ -693,7 +693,7 @@
     "prefix": "devproxy-plugin-rate-limiting-file",
     "body": [
       "{",
-      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/ratelimitingplugin.schema.json\",",
+      "\t\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/ratelimitingplugin.schema.json\",",
       "\t\"body\": {",
       "\t\t$1",
       "\t},",
@@ -708,7 +708,7 @@
   "RateLimitingFileSchema": {
     "prefix": "devproxy-plugin-rate-limiting-file-schema",
     "body": [
-      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.0/ratelimitingplugin.schema.json\","
+      "\"\\$schema\": \"https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.19.1/ratelimitingplugin.schema.json\","
     ],
     "description": "Dev Proxy rate limiting file schema"
   },


### PR DESCRIPTION
- Update snippets to use v0.19.1 schemas. Closes #109
- Update MinimalPermissionsGuidancePlugin snippets. Closes #108
- Update plugin config section names for EntraMockResponsePlugin and GraphMockResponsePlugin. Closes #107
- chore: update package version to 0.6.0
