### PR TITLE
Add information diagnostic when a plugin has optional configSection. Closes #172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 
 - Diagnostics: Ensure at least one plugin is enabled
+- Diagnostics: Information added to pluginName value when plugin can be configured with a configSection
 
 ### Changed:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following sections describe the features that the extension contributes to V
 - Check that schema matches installed version of Dev Proxy
 - Check that reporters are placed after plugins
 - Check that at least one plugin is enabled
+- Check that a plugin can be configured with a configSection
 
 ### Editor Actions
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -198,6 +198,21 @@ const checkPluginConfiguration = (pluginNode: parse.ObjectNode, diagnostics: vsc
             : vscode.DiagnosticSeverity.Warning
         )
       );
+    } else if (pluginSnippet.config?.required === false) {
+      const pluginNameNode = getASTNode(
+        pluginNode.children,
+        'Identifier',
+        'name'
+      );
+      if (pluginNameNode) {
+        diagnostics.push(
+          new vscode.Diagnostic(
+            getRangeFromASTNode(pluginNameNode.value),
+            `${pluginName} can be configured with a configSection. Use '${pluginSnippet.config?.name}' snippet to create one.`,
+            vscode.DiagnosticSeverity.Information
+          )
+        );
+      }
     }
   } else {
     // if there is a config section defined on the plugin, we should have the config section defined in the document

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -506,8 +506,10 @@ suite('schema', () => {
     await sleep(1000);
     const diagnostics = vscode.languages.getDiagnostics(document.uri);
 
-    const expected = 0;
-    const actual = diagnostics.length;
+    const expected = false;
+    const actual = diagnostics.some((diagnostic) => {
+      return diagnostic.severity === vscode.DiagnosticSeverity.Warning;
+    });
     assert.deepStrictEqual(actual, expected);
   });
 


### PR DESCRIPTION
Closes #172
