### PR TITLE
Add warning diagnostic when a configSection exists but is not connected to a plugin. Closes #173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Diagnostics: Ensure at least one plugin is enabled
 - Diagnostics: Information added to pluginName value when plugin can be configured with a configSection
+- Diagnostics: Warning added to config sections not connected to a plugin
 
 ### Changed:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following sections describe the features that the extension contributes to V
 - Check that reporters are placed after plugins
 - Check that at least one plugin is enabled
 - Check that a plugin can be configured with a configSection
+- Check for configSections that are not used in plugins
 
 ### Editor Actions
 


### PR DESCRIPTION
Closes #173 