### PR TITLE
Refactor dev-proxy-toolkit.raise-mock command to use new API endpoint. Closes #222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Command: Refactored stop command logic
 - Diagnostics: Changed check to ensure at least one plugin from Error to Warning
+- Command: `dev-proxy-toolkit.raise-mock` refactored to use new API endpoint
 
 ## [0.18.3] - 2025-03-03
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -145,7 +145,7 @@ export const registerCommands = (context: vscode.ExtensionContext, configuration
     context.subscriptions.push(
         vscode.commands.registerCommand('dev-proxy-toolkit.raise-mock', async () => {
             const apiPort = configuration.get('apiPort') as number;
-            await fetch(`http://localhost:${apiPort}/proxy/raisemockrequest`, {
+            await fetch(`http://localhost:${apiPort}/proxy/mockrequest`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'


### PR DESCRIPTION
Closes #222
